### PR TITLE
Build image only on building configuration changes

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,6 +3,9 @@ name: Build Docker image
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - "Dockerfile"
+      - "hooks/**/*"
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
The Docker image is now only build during Continuous Integration if the Dockerfile or the hooks changed.