### PR TITLE
Docker image build cache

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -37,3 +37,5 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
The Docker image building process is now cached in GitHub Actions cache.