### PR TITLE
Use Docker BuildKit in Continuous Integration

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract tags for the Docker Image
         id: meta
         uses: docker/metadata-action@v5.5.0


### PR DESCRIPTION
The Continuous Integration building pipeline now uses Docker BuildKit.