### PR TITLE
Multi-architecture Docker image build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -16,6 +16,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -39,6 +45,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          platforms: ${{ steps.qemu.outputs.platforms }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha


### PR DESCRIPTION
The Docker image is now built with multiple architecture support.

For now, the target architectures are "amd64" and "arm64".